### PR TITLE
Ajh convert to swift3

### DIFF
--- a/FLIROneSDK.framework/Versions/A/Headers/FLIROneSDKImageEditor.h
+++ b/FLIROneSDK.framework/Versions/A/Headers/FLIROneSDKImageEditor.h
@@ -33,7 +33,7 @@
  @warning Do not attempt to create another instance of this class. Always
  use the sharedInstance class method to retrieve the global singleton.
  */
-@interface FLIROneSDKImageEditor : NSObject <FLIROneSDKImagePropertyController>
+@interface FLIROneSDKImageEditor : FLIROneSDKDelegateManager <FLIROneSDKImagePropertyController>
 
 /**---------------------------------------------------------------------------------------
  * @name Accessing the FLIROneSDKImageEditor sharedInstance

--- a/FLIROneSDK.framework/Versions/A/Headers/FLIROneSDKImageReceiverDelegate.h
+++ b/FLIROneSDK.framework/Versions/A/Headers/FLIROneSDKImageReceiverDelegate.h
@@ -33,7 +33,7 @@
  @param metadata Metadata regarding the particular frame being delivered, such as palette used, emissivity, etc
  */
 
-- (void) FLIROneSDKDelegateManager:(NSObject *)delegateManager didReceiveFrameWithOptions:(FLIROneSDKImageOptions)options metadata:(FLIROneSDKImageMetadata *)metadata;
+- (void) FLIROneSDKDelegateManager:(FLIROneSDKDelegateManager *)delegateManager didReceiveFrameWithOptions:(FLIROneSDKImageOptions)options metadata:(FLIROneSDKImageMetadata *)metadata;
 
 /**
  Called when the user has requested the MSX (thermal + visual) image format
@@ -45,7 +45,7 @@
  @warning The size parameter is guaranteed to be static per-session, but changing FLIR One devices may alter the size parameter
  @see FLIROneSDKUIImage
  */
-- (void) FLIROneSDKDelegateManager:(NSObject *)delegateManager didReceiveBlendedMSXRGBA8888Image:(NSData *)msxImage imageSize:(CGSize)size;
+- (void) FLIROneSDKDelegateManager:(FLIROneSDKDelegateManager *)delegateManager didReceiveBlendedMSXRGBA8888Image:(NSData *)msxImage imageSize:(CGSize)size;
 
 /**
  Called when the user has requested the 14 bit linear flux data
@@ -57,7 +57,7 @@
  @warning The size parameter is guaranteed to be static per-session, but changing FLIR One devices may alter the size parameter
  @see FLIROneSDKUIImage
  */
-- (void) FLIROneSDKDelegateManager:(NSObject *)delegateManager didReceiveThermal14BitLinearFluxImage:(NSData *)linearFluxImage imageSize:(CGSize)size;
+- (void) FLIROneSDKDelegateManager:(FLIROneSDKDelegateManager *)delegateManager didReceiveThermal14BitLinearFluxImage:(NSData *)linearFluxImage imageSize:(CGSize)size;
 /**
  Called when the user has requested the pure thermal image format
  
@@ -68,7 +68,7 @@
  @warning The size parameter is guaranteed to be static per-session, but changing FLIR One devices may alter the size parameter
  @see FLIROneSDKUIImage
  */
-- (void) FLIROneSDKDelegateManager:(NSObject *)delegateManager didReceiveThermalRGBA8888Image:(NSData *)thermalImage imageSize:(CGSize)size;
+- (void) FLIROneSDKDelegateManager:(FLIROneSDKDelegateManager *)delegateManager didReceiveThermalRGBA8888Image:(NSData *)thermalImage imageSize:(CGSize)size;
 /**
  Called when the user has requested the visual image formatted with JPEG
  
@@ -77,7 +77,7 @@
  
  @see FLIROneSDKUIImage
  */
-- (void) FLIROneSDKDelegateManager:(NSObject *)delegateManager didReceiveVisualJPEGImage:(NSData *)visualJPEGImage;
+- (void) FLIROneSDKDelegateManager:(FLIROneSDKDelegateManager *)delegateManager didReceiveVisualJPEGImage:(NSData *)visualJPEGImage;
 /**
  Called when the user has requested the visual image formatted with YCbCr
  
@@ -88,7 +88,7 @@
  @warning The size parameter is guaranteed to be static per-session, but changing FLIR One devices may alter the size parameter
  @see FLIROneSDKUIImage
  */
-- (void) FLIROneSDKDelegateManager:(NSObject *)delegateManager didReceiveVisualYCbCr888Image:(NSData *)visualYCbCr888Image imageSize:(CGSize)size;
+- (void) FLIROneSDKDelegateManager:(FLIROneSDKDelegateManager *)delegateManager didReceiveVisualYCbCr888Image:(NSData *)visualYCbCr888Image imageSize:(CGSize)size;
 
 /**
  Returned when the user has requested radiometric data, once per image load or once per frame delivered by stream manager
@@ -100,6 +100,6 @@
  @warning The size parameter is guaranteed to be static per-session, but changing FLIR One devices may alter the size parameter
  
  */
-- (void) FLIROneSDKDelegateManager:(NSObject *)delegateManager didReceiveRadiometricData:(NSData *)radiometricData imageSize:(CGSize)size;
+- (void) FLIROneSDKDelegateManager:(FLIROneSDKDelegateManager *)delegateManager didReceiveRadiometricData:(NSData *)radiometricData imageSize:(CGSize)size;
 
 @end

--- a/FLIROneSDK.framework/Versions/A/Headers/FLIROneSDKStreamManager.h
+++ b/FLIROneSDK.framework/Versions/A/Headers/FLIROneSDKStreamManager.h
@@ -30,7 +30,7 @@
  @warning Do not attempt to create another instance of this class. Always
  use the sharedInstance class method to retrieve the global singleton.
  */
-@interface FLIROneSDKStreamManager : NSObject <FLIROneSDKImagePropertyController>
+@interface FLIROneSDKStreamManager : FLIROneSDKDelegateManager <FLIROneSDKImagePropertyController>
 
 /**---------------------------------------------------------------------------------------
  * @name Accessing the FLIROneSDKStreamManager sharedInstance

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # flirmebaby
 experiments with FLIR One SDK in Swift
-Prerequisites:
+## Prerequisites:
 https://git-lfs.github.com/

--- a/flirmebaby.xcodeproj/project.pbxproj
+++ b/flirmebaby.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 					3AF762061CC986C100599F6D = {
 						CreatedOnToolsVersion = 7.3;
 						DevelopmentTeam = L7T2AVBQUK;
+						LastSwiftMigration = 0820;
 					};
 				};
 			};
@@ -290,6 +291,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = L7T2AVBQUK;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -303,6 +305,7 @@
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "flirmebaby/flirmebaby-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -314,6 +317,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = L7T2AVBQUK;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -326,6 +330,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "flirmebaby/flirmebaby-Bridging-Header.h";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/flirmebaby/AppDelegate.swift
+++ b/flirmebaby/AppDelegate.swift
@@ -13,30 +13,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/flirmebaby/AppDelegate.swift
+++ b/flirmebaby/AppDelegate.swift
@@ -3,7 +3,6 @@
 //  flirmebaby
 //
 //  Created by Andrew Heim on 4/21/16.
-//  Copyright © 2016 Tonic. All rights reserved.
 //
 
 import UIKit

--- a/flirmebaby/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/flirmebaby/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },

--- a/flirmebaby/Base.lproj/Main.storyboard
+++ b/flirmebaby/Base.lproj/Main.storyboard
@@ -1,9 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12120" systemVersion="16E195" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12088"/>
         <capability name="Alignment constraints with different attributes" minToolsVersion="5.1"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -15,44 +19,44 @@
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="cLy-NX-hib" userLabel="reflected Image View">
-                                <rect key="frame" x="180" y="520" width="240" height="500"/>
+                                <rect key="frame" x="67.5" y="520" width="240" height="500"/>
                             </imageView>
                             <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sdl-PY-WYV">
-                                <rect key="frame" x="0.0" y="520" width="600" height="80"/>
+                                <rect key="frame" x="0.0" y="520" width="375" height="147"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="pls-dY-Cez">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="80"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="147"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VjB-tg-ONZ">
-                                            <rect key="frame" x="0.0" y="10" width="600" height="61"/>
+                                            <rect key="frame" x="0.0" y="43" width="375" height="61"/>
                                             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="KB0-ny-uFP">
-                                                <rect key="frame" x="0.0" y="0.0" width="600" height="61"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="61"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Maximum T = " lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XQn-ol-iob">
-                                                        <rect key="frame" x="191" y="8" width="109" height="20.5"/>
+                                                        <rect key="frame" x="78.5" y="8" width="109" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lDv-mZ-Djr">
-                                                        <rect key="frame" x="300" y="7" width="42" height="21"/>
+                                                        <rect key="frame" x="187.5" y="7" width="42" height="21"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aP5-Lt-TcA">
-                                                        <rect key="frame" x="300" y="32" width="42" height="20.5"/>
+                                                        <rect key="frame" x="187.5" y="32" width="42" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Minimum T = " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JMq-NB-N74">
-                                                        <rect key="frame" x="195" y="32" width="105" height="20.5"/>
+                                                        <rect key="frame" x="82.5" y="32" width="105" height="20.5"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                         <nil key="highlightedColor"/>
@@ -95,11 +99,11 @@
                                 <blurEffect style="light"/>
                             </visualEffectView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Agu-VI-d9D" userLabel="fieldOfVision">
-                                <rect key="frame" x="180" y="20" width="240" height="500"/>
+                                <rect key="frame" x="67.5" y="20" width="240" height="500"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" placeholderIntrinsicWidth="240" placeholderIntrinsicHeight="507.5" translatesAutoresizingMaskIntoConstraints="NO" id="mI2-FF-djY" userLabel="Temperature">
                                         <rect key="frame" x="0.0" y="0.0" width="240" height="500"/>
-                                        <color key="backgroundColor" red="0.80000001190000003" green="0.80000001190000003" blue="0.80000001190000003" alpha="1" colorSpace="calibratedRGB"/>
+                                        <color key="backgroundColor" red="0.80000001190000003" green="0.80000001190000003" blue="0.80000001190000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="500" placeholder="YES" id="bFA-n4-mnq"/>
                                         </constraints>
@@ -111,7 +115,7 @@
                                         <rect key="frame" x="-66" y="-67" width="132" height="134"/>
                                     </imageView>
                                 </subviews>
-                                <color key="backgroundColor" red="0.50990099010000001" green="0.019801980199999999" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" red="0.50990099010000001" green="0.019801980199999999" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="mI2-FF-djY" secondAttribute="trailing" id="2Do-QX-1gq"/>
                                     <constraint firstItem="mI2-FF-djY" firstAttribute="top" secondItem="Agu-VI-d9D" secondAttribute="top" id="BvF-4b-HXj"/>
@@ -124,7 +128,7 @@
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="sdl-PY-WYV" secondAttribute="trailing" id="7NR-Cv-NFe"/>
                             <constraint firstItem="cLy-NX-hib" firstAttribute="centerX" secondItem="Agu-VI-d9D" secondAttribute="centerX" id="9cp-1T-0kS"/>

--- a/flirmebaby/ViewController.swift
+++ b/flirmebaby/ViewController.swift
@@ -1,44 +1,44 @@
 import UIKit
 
-let sizeOfMeasurment = sizeof(UInt16)
+let sizeOfMeasurment = MemoryLayout<UInt16>.size
 let hundredthsOfKelvinToFarenheitDegrees: Float = 0.018
 let absoluteZeroInFarhenheit: Float = -459.67
-let halfOfFLIRPeriod: NSTimeInterval = 0.05555555555556
-let flip = CGAffineTransformMakeScale(1, -1)
+let halfOfFLIRPeriod: TimeInterval = 0.05555555555556
+let flip = CGAffineTransform(scaleX: 1, y: -1)
 
 class ViewController: UIViewController {
 
-    @IBOutlet weak private var imageView: UIImageView!
-    @IBOutlet weak private var maxTemperatureLabel: UILabel!
-    @IBOutlet weak private var minTemperatureLabel: UILabel!
-    @IBOutlet weak private var maxTemperatureCrosshairs: UIImageView!
-    @IBOutlet weak private var minTemperatureCrosshairs: UIImageView!
-    @IBOutlet weak private var maxTemperatureCrosshairsX: NSLayoutConstraint!
-    @IBOutlet weak private var maxTemperatureCrosshairsY: NSLayoutConstraint!
-    @IBOutlet weak private var minTemperatureCrosshairsX: NSLayoutConstraint!
-    @IBOutlet weak private var minTemperatureCrosshairsY: NSLayoutConstraint!
-    @IBOutlet weak private var fieldOfVision: UIView!
-    @IBOutlet weak private var reflection: UIImageView!
+    @IBOutlet weak fileprivate var imageView: UIImageView!
+    @IBOutlet weak fileprivate var maxTemperatureLabel: UILabel!
+    @IBOutlet weak fileprivate var minTemperatureLabel: UILabel!
+    @IBOutlet weak fileprivate var maxTemperatureCrosshairs: UIImageView!
+    @IBOutlet weak fileprivate var minTemperatureCrosshairs: UIImageView!
+    @IBOutlet weak fileprivate var maxTemperatureCrosshairsX: NSLayoutConstraint!
+    @IBOutlet weak fileprivate var maxTemperatureCrosshairsY: NSLayoutConstraint!
+    @IBOutlet weak fileprivate var minTemperatureCrosshairsX: NSLayoutConstraint!
+    @IBOutlet weak fileprivate var minTemperatureCrosshairsY: NSLayoutConstraint!
+    @IBOutlet weak fileprivate var fieldOfVision: UIView!
+    @IBOutlet weak fileprivate var reflection: UIImageView!
 
-    private var xScaleFactor: CGFloat = 1.0
-    private var yScaleFactor: CGFloat = 1.0
-    private var previousSizeOfFieldOfVision = CGSize()
-    private var previousSizeOfImage = CGSize()
-    private weak var flirDataSource: FLIRDataSource? {
+    fileprivate var xScaleFactor: CGFloat = 1.0
+    fileprivate var yScaleFactor: CGFloat = 1.0
+    fileprivate var previousSizeOfFieldOfVision = CGSize()
+    fileprivate var previousSizeOfImage = CGSize()
+    fileprivate weak var flirDataSource: FLIRDataSource? {
         didSet {
-            flirDataSource?.imageOptions = [.BlendedMSXRGBA8888, .RadiometricKelvinx100]//FLIRImageOptions(rawValue: optionsRawValue)
+            flirDataSource?.imageOptions = [.blendedMSXRGBA8888, .radiometricKelvinx100]//FLIRImageOptions(rawValue: optionsRawValue)
             flirDataSource?.showDemo = true
             flirDataSource?.didConnectClosure = {
                 self.flirDataSource?.palette = .Iron
             }
             flirDataSource?.didReceiveImageClosure = { image, size in
-                dispatch_async(dispatch_get_main_queue()) {
+                DispatchQueue.main.async {
                     self.imageView.image = image;
                     self.reflection.image = image;
                 }
             }
             flirDataSource?.didReceiveDataClosure = { data, size in
-                self.seekHotAndCold(data, imageSize: size)
+                self.seekHotAndCold(data as Data, imageSize: size)
             }
         }
     }
@@ -49,17 +49,20 @@ class ViewController: UIViewController {
         flirDataSource = FLIRDataSource()
     }
 
-    func seekHotAndCold(radiometricData: NSData!, imageSize size: CGSize) {
+    func seekHotAndCold(_ radiometricData: Data!, imageSize size: CGSize) {
         var maxTemperature = UInt16()
         var minTemperature = UInt16.max
         var memoryPositionOfMaximumTemperature = 0
         var memoryPositionOfMinimumTemperature = 0
         var currentMemoryPosition = 0
 
-        radiometricData.enumerateByteRangesUsingBlock {(bytes: UnsafePointer<()>, range: NSRange, stop: UnsafeMutablePointer<ObjCBool>) in
-            while currentMemoryPosition < range.length - range.location {
-                let integer = UnsafePointer<UInt16>(bytes + currentMemoryPosition)
-                let temperature = integer.memory
+        radiometricData.enumerateBytes {(buffer: UnsafeBufferPointer<UInt8>, length: Data.Index, stop: inout Bool) in
+            while currentMemoryPosition < length {
+                guard let baseAddress = buffer.baseAddress else {
+                    return
+                }
+                let integer = UnsafeRawPointer(baseAddress + currentMemoryPosition)
+                let temperature = integer.load(as: UInt16.self)
                 if temperature > maxTemperature {
                     maxTemperature = temperature
                     memoryPositionOfMaximumTemperature = currentMemoryPosition
@@ -77,23 +80,23 @@ class ViewController: UIViewController {
         let scaledCoordinatesOfMaxTemperature = scaleCoordinates(coordinatesOfMaxTemperature, toSize: size)
         let coordinatesOfMinTemperature = rowMajorPositionToCoordinates(memoryPositionOfMinimumTemperature / sizeOfMeasurment, rowCount: sizeFloor)
         let scaledCoordinatesOfMinTemperature = scaleCoordinates(coordinatesOfMinTemperature, toSize: size)
-        dispatch_async(dispatch_get_main_queue()) {
+        DispatchQueue.main.async {
             self.maxTemperatureCrosshairsTargetCoordinates(scaledCoordinatesOfMaxTemperature)
             self.minTemperatureCrosshairsTargetCoordinates(scaledCoordinatesOfMinTemperature)
             self.maxTemperatureLabel.text = "\(self.hundredthsOfKelvinInFahrenheit(maxTemperature)) °F";
             self.minTemperatureLabel.text = "\(self.hundredthsOfKelvinInFahrenheit(minTemperature)) °F";
-            UIView.animateWithDuration(halfOfFLIRPeriod) {
+            UIView.animate(withDuration: halfOfFLIRPeriod, animations: {
                 self.view.layoutIfNeeded()
-            }
+            }) 
         }
     }
 
-    private func scaleCoordinates(coordinates: CGPoint, toSize size: CGSize) -> CGPoint {
+    fileprivate func scaleCoordinates(_ coordinates: CGPoint, toSize size: CGSize) -> CGPoint {
         updateScalingForSize(size)
         return CGPoint(x: coordinates.x * xScaleFactor, y: coordinates.y * yScaleFactor)
     }
 
-    private func updateScalingForSize(size: CGSize) {
+    fileprivate func updateScalingForSize(_ size: CGSize) {
         let sizeOfFieldOfVision = fieldOfVision.frame.size
         if size == previousSizeOfImage && sizeOfFieldOfVision == previousSizeOfFieldOfVision {
             return
@@ -104,23 +107,23 @@ class ViewController: UIViewController {
         previousSizeOfFieldOfVision = sizeOfFieldOfVision
     }
 
-    private func maxTemperatureCrosshairsTargetCoordinates(coordinates: CGPoint) {
+    fileprivate func maxTemperatureCrosshairsTargetCoordinates(_ coordinates: CGPoint) {
         self.maxTemperatureCrosshairsX.constant = coordinates.x
         self.maxTemperatureCrosshairsY.constant = coordinates.y
     }
 
-    private func minTemperatureCrosshairsTargetCoordinates(coordinates: CGPoint) {
+    fileprivate func minTemperatureCrosshairsTargetCoordinates(_ coordinates: CGPoint) {
         self.minTemperatureCrosshairsX.constant = coordinates.x
         self.minTemperatureCrosshairsY.constant = coordinates.y
     }
 
-    func rowMajorPositionToCoordinates(position: Int, rowCount: Int) -> CGPoint {
+    func rowMajorPositionToCoordinates(_ position: Int, rowCount: Int) -> CGPoint {
         let x = position % rowCount
         let y = position / rowCount
         return CGPoint(x: CGFloat(x), y: CGFloat(y))
     }
 
-    func hundredthsOfKelvinInFahrenheit(hundredthsOfKelvin: UInt16) -> Float {
+    func hundredthsOfKelvinInFahrenheit(_ hundredthsOfKelvin: UInt16) -> Float {
         return (Float(hundredthsOfKelvin) * hundredthsOfKelvinToFarenheitDegrees + absoluteZeroInFarhenheit)
     }
 }


### PR DESCRIPTION
Use XCode's update tool for upgrading to swift then smooth out the edges. No longer need to change FLIR api to call the delegates NSObjects as was necessary in swift 2. Also need to update the code that enumerates the data in order to find the hottest/coldest position.