### PR TITLE
Add explanation of why one should deny location tracking.

### DIFF
--- a/flirmebaby/Info.plist
+++ b/flirmebaby/Info.plist
@@ -41,5 +41,7 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Given permission, the FLIR One SDK, upon which $(PRODUCT_NAME) depends, geotags images. Otherwise $(PRODUCT_NAME) has no use for your location. You should deny this request.</string>
 </dict>
 </plist>


### PR DESCRIPTION
The solution, since there was no convincing response from FLIR One on how to stop the SDKs attempt to geotag the images, is to write a message requesting that the user deny access to location services.